### PR TITLE
Synchronize extern/ptable with ptable.library 2.0-dev (17.08.2026)

### DIFF
--- a/dist/docs/changes.guide
+++ b/dist/docs/changes.guide
@@ -56,7 +56,7 @@
 
   * @{fg shine}compactflash.device 2.0-dev (17.08.2026)@{fg text} @{i}(new)@{ui}
   * @{fg shine}compactflash.automount 2.0-dev (17.08.2026)@{fg text} @{i}(new)@{ui}
-  * @{fg shine}ptable.library 2.0-dev (30.07.2026)@{fg text} @{i}(new)@{ui}
+  * @{fg shine}ptable.library 2.0-dev (17.08.2026)@{fg text} @{i}(new)@{ui}
   * @{fg shine}CFInfo 1.37 (11.01.2026)@{fg text}
   * @{fg shine}pcmciaspeed 1.36 (02.01.2026)@{fg text}
   * @{fg shine}pcmciacheck 2.0 (06.08.2026)@{fg text} @{i}(new)@{ui}


### PR DESCRIPTION
Moves the extern/ptable pin to the merged ptable master and rebuilds the bundled artifacts.